### PR TITLE
Prevent error if entry is blank

### DIFF
--- a/lib/display_readme.rb
+++ b/lib/display_readme.rb
@@ -15,6 +15,11 @@ class DisplayReadme < Redmine::Hook::ViewListener
     repo = context[:project].repositories.find &blk
 
     entry = repo.entry(path)
+
+    if entry.blank?
+      return ''
+    end
+
     if not entry.is_dir?
       return ''
     end


### PR DESCRIPTION
Hi @rommni !

As the commit message says:
The SCM adapter may return nil in '#entry(path)'.
If it crashes on 'entry.is_dir?'. This change adds an nil check to
prevent it.

We noticed this on our server with the git adapter where I deployed your fork. It happens in unfolded directories on click on a tracked file.
I hope the change will help you and others, too.

In general, do you have any plans to make a PR at simeji original repository of this plugin and share your valuable work?

Cheers!